### PR TITLE
Add Babel for older browsers and replace icons with react-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,57 @@ To learn more, take a look at the following resources:
 - [TailwindCSS Documentation](https://tailwindcss.com/) - learn about TailwindCSS
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+## Babel Installation
+
+To compile your code for older browsers, you need to install Babel and its dependencies. Run the following command:
+
+```bash
+npm install --save-dev @babel/core @babel/preset-env @babel/cli
+```
+
+After installing Babel, you can add a Babel configuration file (`babel.config.json`) to your project root with the following content:
+
+```json
+{
+  "presets": ["@babel/preset-env"]
+}
+```
+
+Now, you can use Babel to compile your code by running:
+
+```bash
+npx babel src --out-dir dist
+```
+
+## React Icons Installation
+
+To use react-icons in your project, you need to install the `react-icons` package. Run the following command:
+
+```bash
+npm install react-icons
+```
+
+After installing the package, you can import and use the icons in your components. For example:
+
+```jsx
+import { FaBars, FaTimes, FaChevronLeft, FaChevronRight, FaWifi, FaLaptop, FaDumbbell, FaUtensils, FaTv, FaConciergeBell } from 'react-icons/fa';
+
+// Usage in a component
+function MyComponent() {
+  return (
+    <div>
+      <FaBars />
+      <FaTimes />
+      <FaChevronLeft />
+      <FaChevronRight />
+      <FaWifi />
+      <FaLaptop />
+      <FaDumbbell />
+      <FaUtensils />
+      <FaTv />
+      <FaConciergeBell />
+    </div>
+  );
+}
+```

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "babel": "npx babel src --out-dir dist"
   },
   "dependencies": {
-    
     "react": "^18",
     "react-dom": "^18",
     "next": "14.0.4"
@@ -17,6 +17,9 @@
   "devDependencies": {
     "autoprefixer": "^10.0.1",
     "postcss": "^8",
-    "tailwindcss": "^3.3.0"
+    "tailwindcss": "^3.3.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "babel-loader": "^8.0.0"
   }
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import "core-js/stable";
 import "regenerator-runtime/runtime";
+import { FaBars, FaTimes, FaChevronLeft, FaChevronRight, FaWifi, FaLaptop, FaDumbbell, FaUtensils, FaTv, FaConciergeBell } from 'react-icons/fa';
 
 function MainComponent() {
   const [currentSlide, setCurrentSlide] = React.useState(0);
@@ -207,7 +208,7 @@ function MainComponent() {
             </ul>
           </nav>
           <button className="md:hidden" onClick={toggleMenu}>
-            <i className={`fas ${isMenuOpen ? "fa-times" : "fa-bars"}`}></i>
+            <FaBars />
           </button>
         </div>
       </header>
@@ -322,13 +323,13 @@ function MainComponent() {
                 onClick={prevSlide}
                 className="absolute left-0 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-r"
               >
-                <i className="fas fa-chevron-left"></i>
+                <FaChevronLeft />
               </button>
               <button
                 onClick={nextSlide}
                 className="absolute right-0 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-l"
               >
-                <i className="fas fa-chevron-right"></i>
+                <FaChevronRight />
               </button>
             </div>
           </section>
@@ -348,7 +349,7 @@ function MainComponent() {
                   onClick={() => setSelectedImage(null)}
                   className="absolute top-4 right-4 text-white text-xl"
                 >
-                  <i className="fas fa-times"></i>
+                  <FaTimes />
                 </button>
               </div>
             </div>
@@ -415,23 +416,22 @@ function MainComponent() {
             <h3 className="text-2xl font-bold mb-4">Amenities</h3>
             <ul className="grid grid-cols-2 md:grid-cols-3 gap-4">
               <li>
-                <i className="fas fa-wifi mr-2"></i> Free Wi-Fi
+                <FaWifi className="mr-2" /> Free Wi-Fi
               </li>
               <li>
-                <i className="fas fa-laptop mr-2"></i> Work Space Area
+                <FaLaptop className="mr-2" /> Work Space Area
               </li>
               <li>
-                <i className="fas fa-dumbbell mr-2"></i> Exercise Room
+                <FaDumbbell className="mr-2" /> Exercise Room
               </li>
               <li>
-                <i className="fas fa-utensils mr-2"></i> Fully Equipped Kitchen
+                <FaUtensils className="mr-2" /> Fully Equipped Kitchen
               </li>
               <li>
-                <i className="fas fa-tv mr-2"></i> Smart TV
+                <FaTv className="mr-2" /> Smart TV
               </li>
               <li>
-                <i className="fas fa-concierge-bell mr-2"></i> Bed & Breakfast
-                Available
+                <FaConciergeBell className="mr-2" /> Bed & Breakfast Available
               </li>
             </ul>
           </section>


### PR DESCRIPTION
Add Babel for compiling to older browsers and replace icons with react-icons.

* **Babel Configuration**
  - Add `@babel/core`, `@babel/preset-env`, and `babel-loader` to `devDependencies` in `package.json`
  - Add a `babel` script to compile code using Babel
  - Create `babel.config.json` with `@babel/preset-env` preset

* **React Icons**
  - Import `FaBars`, `FaTimes`, `FaChevronLeft`, `FaChevronRight`, `FaWifi`, `FaLaptop`, `FaDumbbell`, `FaUtensils`, `FaTv`, `FaConciergeBell` from `react-icons/fa` in `src/app/page.jsx`
  - Replace Font Awesome icons with react-icons in the hamburger menu and amenities section

* **Documentation**
  - Add Babel installation instructions to `README.md`
  - Add react-icons installation instructions to `README.md`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jrman28/officaldeanlanding/pull/14?shareId=5d50cc59-687f-4e4d-b027-b0200c2d0882).