### PR TITLE
Add Guest Booking Agreement drawer to accordion

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -496,6 +496,12 @@ function MainComponent() {
                   answer:
                     "For a Firm cancellation policy, guests must cancel up to 60 days before your trip and only pay 50% of the total accommodation fees for the reservation. Cancel within 60 days of the trip and the reservation is non-refundable.",
                 },
+                {
+                  question: "Guest Booking Agreement",
+                  answer:
+                    "You can view the Guest Booking Agreement by clicking the link below.",
+                  link: "https://drive.google.com/file/d/1acdaOQ2ySdDea8mQBusPRCpeCLN_KR6y/view?usp=sharing",
+                },
               ].map((faq, index) => (
                 <div
                   key={index}
@@ -511,7 +517,19 @@ function MainComponent() {
                     </span>
                   </button>
                   {activeAccordion === index && (
-                    <p className="mt-2">{faq.answer}</p>
+                    <div className="mt-2">
+                      <p>{faq.answer}</p>
+                      {faq.link && (
+                        <a
+                          href={faq.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-teal-500 underline"
+                        >
+                          View Agreement
+                        </a>
+                      )}
+                    </div>
                   )}
                 </div>
               ))}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -496,12 +496,6 @@ function MainComponent() {
                   answer:
                     "For a Firm cancellation policy, guests must cancel up to 60 days before your trip and only pay 50% of the total accommodation fees for the reservation. Cancel within 60 days of the trip and the reservation is non-refundable.",
                 },
-                {
-                  question: "Guest Booking Agreement",
-                  answer:
-                    "You can view the Guest Booking Agreement by clicking the link below.",
-                  link: "https://drive.google.com/file/d/1acdaOQ2ySdDea8mQBusPRCpeCLN_KR6y/view?usp=sharing",
-                },
               ].map((faq, index) => (
                 <div
                   key={index}
@@ -519,16 +513,6 @@ function MainComponent() {
                   {activeAccordion === index && (
                     <div className="mt-2">
                       <p>{faq.answer}</p>
-                      {faq.link && (
-                        <a
-                          href={faq.link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-teal-500 underline"
-                        >
-                          View Agreement
-                        </a>
-                      )}
                     </div>
                   )}
                 </div>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -533,6 +533,29 @@ function MainComponent() {
                   )}
                 </div>
               ))}
+              <div className="border-b border-gray-200 pb-4 last:border-b-0">
+                <button
+                  className="flex justify-between items-center w-full text-left font-bold focus:outline-none"
+                  onClick={() => toggleAccordion(3)}
+                >
+                  <span>Guest Booking Agreement?</span>
+                  <span className="text-xl">
+                    {activeAccordion === 3 ? "−" : "+"}
+                  </span>
+                </button>
+                {activeAccordion === 3 && (
+                  <div className="mt-2">
+                    <a
+                      href="https://drive.google.com/file/d/1acdaOQ2ySdDea8mQBusPRCpeCLN_KR6y/view?usp=sharing"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-teal-500 underline"
+                    >
+                      View Agreement
+                    </a>
+                  </div>
+                )}
+              </div>
             </div>
           </section>
         </div>


### PR DESCRIPTION
Add a 4th drawer labeled "Guest Booking Agreement" to the accordion in `src/app/page.jsx`.

* Add a new drawer labeled "Guest Booking Agreement" at the bottom of the accordion.
* Set the content of the new drawer to a URL link: https://drive.google.com/file/d/1acdaOQ2ySdDea8mQBusPRCpeCLN_KR6y/view?usp=sharing.
* Follow the style of the existing accordion drawers for the new drawer.
* Ensure the URL works properly within the accordion drawer.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jrman28/officaldeanlanding/pull/18?shareId=050a3d92-83ce-44a7-81d1-d497086d077a).